### PR TITLE
Include M5EPD dependency in platformio.ini

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -19,3 +19,5 @@ build_flags =
 	-DCORE_DEBUG_LEVEL=4
 	-DBOARD_HAS_PSRAM
 	-mfix-esp32-psram-cache-issue
+lib_deps = 
+	https://github.com/m5stack/M5EPD.git


### PR DESCRIPTION
This makes platformio build work without extra configuration.

Resolves #1.