### PR TITLE
Update platformio.ini to resolve upload failure

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -12,7 +12,7 @@
 platform = espressif32
 board = m5stack-fire
 framework = arduino
-upload_speed = 2000000
+upload_speed = 115200
 monitor_speed = 115200
 board_build.partitions = default_16MB.csv
 build_flags = 


### PR DESCRIPTION
A fatal error occurred: Invalid head of packet would occur because the upload speed or baud rate was too fast.
My M5Paper would not accept uploads at that higher baud rate