### PR TITLE
Use latest working platform package version

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -12,7 +12,7 @@
 platform = espressif32@^4.1.0
 board = m5stack-fire
 framework = arduino
-platform_packages = platformio/framework-arduinoespressif32@3.20004.220825
+platform_packages = platformio/framework-arduinoespressif32@3.20004.0
 upload_speed = 1500000
 monitor_speed = 115200
 board_build.partitions = default_16MB.csv


### PR DESCRIPTION
Closes https://github.com/m5stack/M5Paper_FactoryTest/issues/15

According to https://registry.platformio.org/tools/platformio/framework-arduinoespressif32/versions, `platformio/framework-arduinoespressif32@3.20004.0` is the latest one and I cannot see any other `3.20004` on that list.

This version is present for macOs and works after flashing.

Note:

* if I remove the version at all, `framework-arduinoespressif32 @ 3.20003.220626` will be used and it also present for mac and works
* if I use the latest version as `platform_packages = platformio/framework-arduinoespressif32@3.20005.220925`, the project fails to compile:

```
*******************************************************************
* Looking for sdkconfig.h dependency? Check our library registry!
*
* CLI  > platformio lib search "header:sdkconfig.h"
* Web  > https://registry.platformio.org/search?q=header:sdkconfig.h
*
*******************************************************************

 #include <sdkconfig.h>
          ^~~~~~~~~~~~~
compilation terminated.
compilation terminated.
*** [.pio/build/m5stack-fire/src/frame/frame_compare.cpp.o] Error 1
*** [.pio/build/m5stack-fire/src/frame/frame_base.cpp.o] Error 1
```