### PR TITLE
Fix not being able to select the first item in the Wifi list without a crash.

### DIFF
--- a/src/frame/frame_wifiscan.cpp
+++ b/src/frame/frame_wifiscan.cpp
@@ -169,11 +169,11 @@ int Frame_WifiScan::scan() {
         DrawItem(_key_wifi[cnt], ssid, WiFi.RSSI(idx));
         _key_wifi[cnt]->Draw(UPDATE_MODE_A2);
 
-        idx++;
         if (idx == wifi_num) {
             break;
         }
 
+        idx++;
         cnt++;
     }
 


### PR DESCRIPTION
in `frame_wifiscan.cpp`  idx is incremented before checking if the menu item is that id, causing it never to be found, and over run, causing a crash. Fix was to inc after check.